### PR TITLE
MISC - watch react-hook-form field value change

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,6 @@
 import { DevTool } from '@hookform/devtools';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button, Checkbox, Form, Input } from 'antd';
+import { Button, Checkbox, Form, Input, Space } from 'antd';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -16,10 +16,18 @@ const schema = z.object({
 });
 
 const App = () => {
-  const { control, handleSubmit } = useForm({
+  const { control, handleSubmit, reset } = useForm({
     defaultValues: { username: 'jsun969', password: '', remember: true },
     resolver: zodResolver(schema),
   });
+
+  const resetForm = () => {
+    reset({
+      username: '',
+      password: '',
+      remember: false,
+    });
+  };
 
   return (
     <>
@@ -44,9 +52,12 @@ const App = () => {
           <Checkbox>Remember me</Checkbox>
         </FormItem>
         <Form.Item>
-          <Button type="primary" htmlType="submit">
-            Submit
-          </Button>
+          <Space>
+            <Button type="primary" htmlType="submit">
+              Submit
+            </Button>
+            <Button onClick={resetForm}>Reset</Button>
+          </Space>
         </Form.Item>
       </Form>
       <DevTool control={control} />

--- a/src/FormItem.tsx
+++ b/src/FormItem.tsx
@@ -21,10 +21,10 @@ export const FormItem = <TFieldValues extends FieldValues = FieldValues>({
   help,
   ...props
 }: FormItemProps<TFieldValues>) => {
-  const form = AntdForm.useFormInstance();
   const { field, fieldState } = useController(
-    control ? { name } : { name, control },
+    control ? { name, control } : { name },
   );
+  const form = AntdForm.useFormInstance();
 
   const handleNormalize: AntdFormItemProps['normalize'] = (value) => {
     field.onChange(value);

--- a/src/FormItem.tsx
+++ b/src/FormItem.tsx
@@ -1,5 +1,6 @@
 import { Form as AntdForm } from 'antd';
 import type React from 'react';
+import { useEffect } from 'react';
 import type { Control, FieldPath, FieldValues } from 'react-hook-form';
 import { useController } from 'react-hook-form';
 
@@ -21,11 +22,22 @@ export const FormItem = <TFieldValues extends FieldValues = FieldValues>({
   ...props
 }: FormItemProps<TFieldValues>) => {
   const { field, fieldState } = useController({ name, control });
+  const form = AntdForm.useFormInstance();
 
   const handleNormalize: AntdFormItemProps['normalize'] = (value) => {
     field.onChange(value);
     return value;
   };
+
+  useEffect(() => {
+    if (!form) return;
+
+    const prevFieldValue = form.getFieldValue(name);
+    const latestFieldValue = field.value;
+
+    if (prevFieldValue !== latestFieldValue)
+      form.setFieldValue(name, field.value);
+  }, [form, name, field.value]);
 
   return (
     <AntdForm.Item

--- a/src/FormItem.tsx
+++ b/src/FormItem.tsx
@@ -2,7 +2,7 @@ import { Form as AntdForm } from 'antd';
 import type React from 'react';
 import { useEffect } from 'react';
 import type { Control, FieldPath, FieldValues } from 'react-hook-form';
-import { useController, useFormContext } from 'react-hook-form';
+import { useController } from 'react-hook-form';
 
 type AntdFormItemProps = React.ComponentProps<typeof AntdForm.Item>;
 

--- a/src/FormItem.tsx
+++ b/src/FormItem.tsx
@@ -2,14 +2,14 @@ import { Form as AntdForm } from 'antd';
 import type React from 'react';
 import { useEffect } from 'react';
 import type { Control, FieldPath, FieldValues } from 'react-hook-form';
-import { useController } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 
 type AntdFormItemProps = React.ComponentProps<typeof AntdForm.Item>;
 
 export type FormItemProps<TFieldValues extends FieldValues = FieldValues> = {
   children: React.ReactNode;
-  control: Control<TFieldValues>;
   name: FieldPath<TFieldValues>;
+  control?: Control<TFieldValues>;
 } & Omit<AntdFormItemProps, 'name' | 'normalize' | 'rules' | 'validateStatus'>;
 
 // TODO: Support `onBlur` `ref`
@@ -21,8 +21,10 @@ export const FormItem = <TFieldValues extends FieldValues = FieldValues>({
   help,
   ...props
 }: FormItemProps<TFieldValues>) => {
-  const { field, fieldState } = useController({ name, control });
   const form = AntdForm.useFormInstance();
+  const { field, fieldState } = useController(
+    control ? { name } : { name, control },
+  );
 
   const handleNormalize: AntdFormItemProps['normalize'] = (value) => {
     field.onChange(value);


### PR DESCRIPTION
- watch react-hook-form field value change to fix the `reset` function not working
- update form-item props to leave `control` optional
- added `reset` example to the example project

Fix #3 