### PR TITLE
fix: pass disabled prop to underlying controller

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "antd": "^5.10.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.47.0",
+    "react-hook-form": "^7.48.2",
     "zod": "^3.22.3"
   },
   "devDependencies": {

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.3.2
-    version: 3.3.2(react-hook-form@7.47.0)
+    version: 3.3.2(react-hook-form@7.48.2)
   antd:
     specifier: ^5.10.3
     version: 5.10.3(react-dom@18.2.0)(react@18.2.0)
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
   react-hook-form:
-    specifier: ^7.47.0
-    version: 7.47.0(react@18.2.0)
+    specifier: ^7.48.2
+    version: 7.48.2(react@18.2.0)
   zod:
     specifier: ^3.22.3
     version: 3.22.3
@@ -765,12 +765,12 @@ packages:
       - '@types/react'
     dev: true
 
-  /@hookform/resolvers@3.3.2(react-hook-form@7.47.0):
+  /@hookform/resolvers@3.3.2(react-hook-form@7.48.2):
     resolution: {integrity: sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==}
     peerDependencies:
       react-hook-form: ^7.0.0
     dependencies:
-      react-hook-form: 7.47.0(react@18.2.0)
+      react-hook-form: 7.48.2(react@18.2.0)
     dev: false
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -1882,8 +1882,8 @@ packages:
       react: 18.2.0
       scheduler: 0.23.0
 
-  /react-hook-form@7.47.0(react@18.2.0):
-    resolution: {integrity: sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==}
+  /react-hook-form@7.48.2(react@18.2.0):
+    resolution: {integrity: sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,7 +16,7 @@ const schema = z.object({
 });
 
 const App = () => {
-  const { control, handleSubmit, reset } = useForm({
+  const { control, watch, handleSubmit, reset } = useForm({
     defaultValues: { username: 'jsun969', password: '', remember: true },
     resolver: zodResolver(schema),
   });
@@ -37,7 +37,7 @@ const App = () => {
         >
           <Input />
         </FormItem>
-        <FormItem control={control} name="password" label="Password">
+        <FormItem control={control} name="password" label="Password" disabled={!watch('username')}>
           <Input.Password />
         </FormItem>
         <FormItem control={control} name="remember" valuePropName="checked">

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.43.9",
+    "react-hook-form": "^7.48.2",
     "simple-git-hooks": "^2.9.0",
     "tsup": "^6.7.0",
     "typescript": "^5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ devDependencies:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
   react-hook-form:
-    specifier: ^7.43.9
-    version: 7.47.0(react@18.2.0)
+    specifier: ^7.48.2
+    version: 7.48.2(react@18.2.0)
   simple-git-hooks:
     specifier: ^2.9.0
     version: 2.9.0
@@ -3051,8 +3051,8 @@ packages:
       scheduler: 0.23.0
     dev: true
 
-  /react-hook-form@7.47.0(react@18.2.0):
-    resolution: {integrity: sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==}
+  /react-hook-form@7.48.2(react@18.2.0):
+    resolution: {integrity: sha512-H0T2InFQb1hX7qKtDIZmvpU1Xfn/bdahWBN1fH19gSe4bBEqTfmlr7H3XWTaVtiK4/tpPaI1F3355GPMZYge+A==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18

--- a/src/FormItem.tsx
+++ b/src/FormItem.tsx
@@ -10,6 +10,7 @@ export type FormItemProps<TFieldValues extends FieldValues = FieldValues> = {
   children: React.ReactNode;
   control: Control<TFieldValues>;
   name: FieldPath<TFieldValues>;
+  disabled?: boolean;
 } & Omit<AntdFormItemProps, 'name' | 'rules' | 'validateStatus'>;
 
 // TODO: Support `onBlur` `ref`
@@ -17,11 +18,12 @@ export const FormItem = <TFieldValues extends FieldValues = FieldValues>({
   children,
   control,
   name,
+  disabled,
   help,
   valuePropName,
   ...props
 }: FormItemProps<TFieldValues>) => {
-  const { field, fieldState } = useController({ name, control });
+  const { field, fieldState } = useController({ name, control, disabled });
 
   return (
     <AntdForm.Item


### PR DESCRIPTION
One of the [latest updates ](https://github.com/react-hook-form/react-hook-form/releases/tag/v7.48.0) of `react-hook-form` (7.48.0) breaks passing the `disabled` prop to the underlying Ant component.

This fixes the aforementioned behaviour and allows the users to pass the `disabled` prop the controller directly, resolving issue #36.