### PR TITLE
Fix: Ensure Values Update When Removing Elements in Listed Component by Watching name in useEffect Dependencies

### DIFF
--- a/src/FormItem.tsx
+++ b/src/FormItem.tsx
@@ -29,7 +29,7 @@ export const FormItem = <TFieldValues extends FieldValues = FieldValues>({
 
 	useEffect(() => {
 		form.setFieldValue(name, field.value);
-	}, [field.value]);
+	}, [field.value, form, name]);
 
 	return (
 		<AntdForm.Item


### PR DESCRIPTION
When removing elements in a listed component, the values are not updated.
This is because the name is not being watched in the useEffect dependencies.
A warning should be output by ESLint as well.

```
$ eslint "src/FormItem.tsx"

~/works/react-hook-form-antd/src/FormItem.tsx
  13:38  error    Unexpected any. Specify a different type                                                                              @typescript-eslint/no-explicit-any
  32:5   warning  React Hook useEffect has missing dependencies: 'form' and 'name'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

✖ 2 problems (1 error, 1 warning)
```