### PR TITLE
Add react 19 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 	"peerDependencies": {
 		"antd": "^5",
 		"react": "^16.8.0 || ^17 || ^18 || ^19",
-		"react-dom": "^16.8.0 || ^17 || ^18",
+		"react-dom": "^16.8.0 || ^17 || ^18 || ^19",
 		"react-hook-form": "^7"
 	},
 	"lint-staged": {


### PR DESCRIPTION
Adds react 19 as a supported peer dependency as discussed in https://github.com/jsun969/react-hook-form-antd/issues/105

resolve #105 