### PR TITLE
Add antd 6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20]
+        antd-version: [5, 6]
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
@@ -21,5 +22,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
+      - name: Install antd version
+        run: pnpm add antd@${{ matrix.antd-version }}
       - name: Run tests
         run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"zod": "^3.22.4"
 	},
 	"peerDependencies": {
-		"antd": "^5",
+		"antd": "^5 || ^6",
 		"react": "^16.8.0 || ^17 || ^18 || ^19",
 		"react-dom": "^16.8.0 || ^17 || ^18 || ^19",
 		"react-hook-form": "^7"


### PR DESCRIPTION
## What

Add support for antd v6 in peerDependencies.

## Why

Currently, the library works correctly with antd v6, but npm shows a peer dependency conflict.  https://github.com/jsun969/react-hook-form-antd/issues/108

## Changes

- updated peerDependencies:
  "antd": "^5 || ^6"

## Testing

Tested locally with:
- antd v6
- react-hook-form

All functionality works as expected.