### PR TITLE
ci: Fixed ubuntu version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ env:
   PNPM_VERSION: 9
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [20]


### PR DESCRIPTION
### 🚀 Update GitHub Actions runner to `ubuntu-latest`

#### Summary

This PR updates the GitHub Actions runner from `ubuntu-20.04` to `ubuntu-latest`.

#### Motivation

According to the official GitHub announcement (Jan 15, 2025), the `ubuntu-20.04` runner image is being deprecated and is scheduled for full retirement. As part of this process, GitHub introduced brownout periods and eventual shutdown, which can lead to jobs being stuck in a "Waiting for a runner to pick up this job..." state.

In practice, this is already affecting CI reliability.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down

#### Changes

* Replaced:

  ```yaml
  runs-on: ubuntu-20.04
  ```

  with:

  ```yaml
  runs-on: ubuntu-latest
  ```

#### Benefits

* Restores CI job execution (no more stuck jobs)
* Ensures compatibility with supported GitHub-hosted runners
* Keeps the project aligned with GitHub Actions platform updates

#### Notes

* `ubuntu-latest` currently resolves to a maintained version (e.g. 22.04 or newer)
* No breaking changes are expected, but CI run will validate this

---

If preferred, we can pin to a specific version like `ubuntu-22.04` instead of using `latest`.
